### PR TITLE
Fix: Update Instagram link in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -142,7 +142,8 @@ export default function Footer() {
                 <Linkedin size={20} />
               </a> */}
               <a
-                href="https://www.instagram.com/geekroom_kiet//"
+                href="https://www.instagram.com/geekroom_kiet/"
+
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-primary transition-colors"


### PR DESCRIPTION
This PR fixes the broken Instagram link in the footer.

- Updated the href to point to the correct account: https://www.instagram.com/geekroom_kiet/

Fixes #19 
