### PR TITLE
Fix/navbar alignment bug

### DIFF
--- a/src/components/WhyJoinUsSection.tsx
+++ b/src/components/WhyJoinUsSection.tsx
@@ -350,14 +350,14 @@ const WhyJoinUsSection = () => {
   ];
 
   return (
-    <section className="py-16 md:py-24 bg-gradient-to-br from-gray-900 to-black relative overflow-hidden">
+    <section className="pt-32 pb-24 md:py-24 bg-gradient-to-br from-gray-900 to-black relative overflow-hidden">
       <div className="container mx-auto px-4 md:px-6">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
           {/* Left Content */}
           <div className="space-y-8 mt-10">
             <h2 
               ref={titleRef}
-              className="text-4xl md:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-[#FF2D55] to-[#786EFF]"
+              className="text-4xl md:text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-[#FF2D55] to-[#786EFF] pb-2"
             >
               Why Join Us?
             </h2>


### PR DESCRIPTION
### Closes: #6 

### Description
Fixed the content clashing with navbar in the mobile-view and added bottom padding to "Why join us" in webview to prevent the 'y' from being cutoff.

### Changes Made
- Added top padding to 128px and bottom padding to 96px of heading element in mobile-view
- Adds 8px of bottom padding to the heading element

### Screenshots/GIFs
<img width="385" height="630" alt="Screenshot 2025-09-14 160055" src="https://github.com/user-attachments/assets/35ce8346-88b3-46e8-b701-2cf3316f7edc" />
<img width="1919" height="998" alt="Screenshot 2025-09-14 160119" src="https://github.com/user-attachments/assets/77ee6468-9447-45d1-9fe9-533efb5dfb72" />


### Checklist
- [✅] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [✅] My code follows the project’s coding standards
- [✅] I have tested my changes locally
- [✅] I have linked this PR to the issue 