### PR TITLE
fix made the floating avatar responsive

### DIFF
--- a/src/components/WhyJoinUsSection.tsx
+++ b/src/components/WhyJoinUsSection.tsx
@@ -58,7 +58,7 @@ const FloatingAvatar: React.FC<FloatingAvatarProps> = ({
 
       // Continuous floating animation
       gsap.to(avatarRef.current, {
-        y: "+=15",
+        y: "+=10",
         duration: 2 + Math.random() * 2,
         ease: "sine.inOut",
         yoyo: true,
@@ -78,10 +78,10 @@ const FloatingAvatar: React.FC<FloatingAvatarProps> = ({
   }, [delay]);
 
   const sizeClasses = {
-    sm: "w-12 h-12",
-    md: "w-16 h-16", 
-    lg: "w-20 h-20",
-    xl: "w-24 h-24"
+    sm: "w-8 h-8 md:w-12 md:h-12",
+    md: "w-12 h-12 md:w-16 md:h-16", 
+    lg: "w-14 h-14 md:w-20 md:h-20",
+    xl: "w-16 h-16 md:w-24 md:h-24"
   };
 
   return (
@@ -89,18 +89,23 @@ const FloatingAvatar: React.FC<FloatingAvatarProps> = ({
       id={id}
       ref={avatarRef}
       className="absolute"
-      style={{ top: `${top}px`, left: `${left}px` }}
+      style={{ 
+        top: `${top*1 }px`, 
+        left: `${left * 0.7}px`
+      }}
     >
       <div 
-        className={`${sizeClasses[size]} rounded-full overflow-hidden border-4 shadow-lg relative`}
-        style={{ borderColor: borderColor || '#FF2D55' }}
+        className={`${sizeClasses[size]} rounded-full overflow-hidden border-2 md:border-4 shadow-lg relative`}
+        style={{ 
+          borderColor: borderColor || '#FF2D55',
+        }}
       >
         <Image
           src={src}
           alt={alt}
           fill
           className="object-cover"
-          sizes="96px"
+          sizes="(max-width: 768px) 64px, 96px"
         />
         <div 
           className="absolute inset-0 rounded-full"
@@ -339,13 +344,13 @@ const WhyJoinUsSection = () => {
       label: "Events",
       color: "#FF2D55", 
       top: 110,
-      left: 320
+      left: 250
     },
     {
       label: "Learning",
       color: "#786EFF",
-      top: 320,
-      left: 180
+      top: 328,
+      left: 140
     }
   ];
 


### PR DESCRIPTION
Closes: #39

[BUG] Fix responsiveness on Homepage

Description

I’ve made some small changes to improve how the homepage looks on phones. The layout is now more responsive and works better on smaller screens.

Since we already use GSAP for animations, I think it would look even nicer if avatars move a bit differently on each device (mobile, tablet, desktop). The current fix works fine, but adding this extra movement can make the page feel smoother. If you like the idea, I can also work on that.

Changes Made

Fixed responsiveness issues on Homepage

Improved avatar animation for better fit on phones

Idea: add device-specific GSAP movement (extra polish for different screen sizes)

Screenshots/GIFs


<img width="408" height="752" alt="Screenshot 2025-09-21 193147" src="https://github.com/user-attachments/assets/cf43778c-ac99-46b5-8724-e78ecce9e208" />


Checklist

 I have read the contributing.md

 My code follows the project’s coding standards

 I have tested my changes locally

 I have linked this PR to the issue